### PR TITLE
[FEAT] 질문지 자세하게 선택 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
         android:theme="@style/Theme.NaeunAndroid"
         tools:targetApi="31">
         <activity
+            android:name=".presentation.QuestionnaireActivity"
+            android:exported="false" />
+        <activity
             android:name=".presentation.SelectSkinTypeActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/naeun_android/data/model/Question.kt
+++ b/app/src/main/java/com/naeun_android/data/model/Question.kt
@@ -1,0 +1,6 @@
+package com.naeun_android.data.model
+
+data class Question(
+    val title: String,
+    val options: List<String>,
+)

--- a/app/src/main/java/com/naeun_android/presentation/QuestionnaireActivity.kt
+++ b/app/src/main/java/com/naeun_android/presentation/QuestionnaireActivity.kt
@@ -1,0 +1,147 @@
+package com.naeun_android.presentation
+
+import android.os.Bundle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.naeun_android.R
+import com.naeun_android.data.model.Question
+import com.naeun_android.databinding.ActivityQuestionnaireBinding
+import com.naeun_android.util.BindingActivity
+import java.lang.Integer.min
+
+class QuestionnaireActivity :
+    BindingActivity<ActivityQuestionnaireBinding>(R.layout.activity_questionnaire) {
+    private var currentQuestionIndex = 0
+    private lateinit var questionAdapter: QuestionnaireAdapter
+    private lateinit var questions: List<Question>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        questions = generateSampleQuestions()
+        questionAdapter = QuestionnaireAdapter(
+            questions.subList(currentQuestionIndex, getNextQuestionIndex()),
+        )
+
+        binding.rvQuestions.layoutManager = LinearLayoutManager(this)
+        binding.rvQuestions.adapter = questionAdapter
+
+        binding.btnNext.setOnClickListener {
+            currentQuestionIndex = getNextQuestionIndex()
+            questionAdapter.updateQuestionsSubset(
+                questions.subList(currentQuestionIndex, getNextQuestionIndex()),
+            )
+        }
+    }
+
+    private fun generateSampleQuestions(): List<Question> {
+        val questions = mutableListOf<Question>()
+        questions.add(
+            Question(
+                "Q1. 세안 후, 아무 것도 바르지 않고 2-3시간 지나면 내 이마와 볼은",
+                listOf(
+                    "1매우 거칠고, 버석거리며 각질이 들떠 보인다.",
+                    "1당긴다.",
+                    "1당기지 않고 건조해 보이지 않으며 번들거리지 않는다.",
+                    "1밝은 빛에 반사되는 것처럼 번들거린다.",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q2. 세안 후, 아무 것도 바르지 않고 2-3시간 지나면 내 이마와 볼은",
+                listOf(
+                    "2매우 거칠고, 버석거리며 각질이 들떠 보인다.",
+                    "2당긴다.",
+                    "2당기지 않고 건조해 보이지 않으며 번들거리지 않는다.",
+                    "2밝은 빛에 반사되는 것처럼 번들거린다.",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q3. 파우더를 바르지 않은 상태에서, 파운데이션을 바른 지 2-3시간 후 메이크업의 상태가 어떻습니까?",
+                listOf(
+                    "약간 들떠 보이고 주름에 낀다.",
+                    "부드러워 보인다.",
+                    "번들거린다..",
+                    "고정이 안 되고 번들거린다.",
+                    "애초에 파운데이션을 바르지 않는다.",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q4. 세안 후, 아무 것도 바르지 않고 2-3시간 지나면 내 이마와 볼은",
+                listOf(
+                    "건조하고 갈라질 것 같다.",
+                    "당긴다.",
+                    "정상적이다.",
+                    "번들거리며, 로션과 크림이 필요 없다.",
+                    "잘 모르겠다.",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q5. 모공이 많고 사이즈가 큽니까?",
+                listOf(
+                    "아니다.",
+                    "이마와 코에 두드러져 보인다.",
+                    "많다.",
+                    "매우 많다.",
+                    "잘 모르겠다.",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q6. 평소 내 피부 타입이 뭐라고 생각합니까?",
+                listOf(
+                    "건성",
+                    "중성",
+                    "복합",
+                    "지성",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q7. 화이트헤드나 블랙헤드가 있습니까?",
+                listOf(
+                    "없다",
+                    "거의 없다",
+                    "조금 있다",
+                    "많다",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q8. 이마와 코 부위가 번들거리는 느낌이 듭니까?",
+                listOf(
+                    "전혀 그렇지 않다.",
+                    "가끔 그렇다",
+                    "자주 그렇다.",
+                    "항상 그렇다.",
+                ),
+            ),
+        )
+        questions.add(
+            Question(
+                "Q9. 수분용 로션이나 크림을 바르고 2-3시간 후 볼의 피부 상태는",
+                listOf(
+                    "매우 거칠고, 각질이 일어나거나 각질이 떨어진다.",
+                    "부드럽다.",
+                    "조금 번들거린다.",
+                    "번들거리고 기름진다.",
+                ),
+            ),
+        )
+        return questions
+    }
+
+    private fun getNextQuestionIndex(): Int {
+        // TODO : 모든 질문 추가 후, 각 페이지별 인덱스 증가
+        return min(currentQuestionIndex + 2, questions.size)
+    }
+}

--- a/app/src/main/java/com/naeun_android/presentation/QuestionnaireAdapter.kt
+++ b/app/src/main/java/com/naeun_android/presentation/QuestionnaireAdapter.kt
@@ -1,0 +1,55 @@
+package com.naeun_android.presentation
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.naeun_android.R
+import com.naeun_android.data.model.Question
+
+class QuestionnaireAdapter(private var questions: List<Question>) :
+    RecyclerView.Adapter<QuestionnaireAdapter.QuestionViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuestionViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_questionnaire_selection, parent, false)
+        return QuestionViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: QuestionViewHolder, position: Int) {
+        val question = questions[position]
+        holder.bind(question)
+    }
+
+    override fun getItemCount(): Int {
+        return questions.size
+    }
+
+    fun updateQuestionsSubset(subset: List<Question>) {
+        questions = subset
+        notifyDataSetChanged()
+    }
+
+    inner class QuestionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val titleTextView: TextView = itemView.findViewById(R.id.tv_question)
+        private val radioGroup: RadioGroup = itemView.findViewById(R.id.radio_group_options)
+
+        fun bind(question: Question) {
+            titleTextView.text = question.title
+            addOptionsToRadioGroup(question.options)
+        }
+
+        private fun addOptionsToRadioGroup(options: List<String>) {
+            radioGroup.removeAllViews()
+
+            options.forEach { option ->
+                val radioButton = RadioButton(itemView.context)
+                radioButton.text = option
+                radioGroup.addView(radioButton)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/rectangle_gray10_radius_10dp.xml
+++ b/app/src/main/res/drawable/rectangle_gray10_radius_10dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="10dp" />
+    <solid android:color="@color/gray10" />
+</shape>

--- a/app/src/main/res/drawable/rectangle_gray_radius_10dp.xml
+++ b/app/src/main/res/drawable/rectangle_gray_radius_10dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="10dp" />
+    <solid android:color="#D9D9D9" />
+</shape>

--- a/app/src/main/res/layout/activity_questionnaire.xml
+++ b/app/src/main/res/layout/activity_questionnaire.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginHorizontal="23dp"
+        tools:context=".presentation.QuestionnaireActivity">
+
+
+        <ImageView
+            android:id="@+id/iv_back"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:src="@drawable/ic_back"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_question_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:text="1. D or O"
+            android:textSize="40sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_back" />
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="13dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_question_title">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/rectangle_gray10_radius_10dp"
+                android:paddingBottom="20dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_question_title">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_questions"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingVertical="9dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:itemCount="3"
+                    tools:listitem="@layout/item_questionnaire_selection" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.core.widget.NestedScrollView>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_previous"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="3dp"
+            android:layout_marginBottom="22dp"
+            android:background="@drawable/rectangle_gray_radius_10dp"
+            android:enabled="true"
+            android:letterSpacing="0.1"
+            android:stateListAnimator="@null"
+            android:text="이전"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/btn_next"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_next"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="3dp"
+            android:layout_marginBottom="22dp"
+            android:background="@drawable/shape_main_radius_10dp"
+            android:enabled="true"
+            android:letterSpacing="0.1"
+            android:stateListAnimator="@null"
+            android:text="다음"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_previous" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/item_questionnaire_selection.xml
+++ b/app/src/main/res/layout/item_questionnaire_selection.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_marginHorizontal="12dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tv_question"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Q1. 세안 후, 아무 것도 바르지 않고 2-3시간 지나면 내 이마와 볼은" />
+
+    <RadioGroup
+        android:id="@+id/radio_group_options"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:orientation="vertical"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_question" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## One line Description
- 질문지 자세하게 선택 구현

## Work Detail(Optional)
**1. 리사이클러뷰로 질문 / 선택지(라디오그룹) 구현**

**2. 페이지 넘김 시 아이템 갯수 더해서 다음 질문으로 넘기기**

- 현재는 기능 확인을 위해 한 화면에 2개만 뜸
- 추후 모든 질문 추가 후 각 페이지 별 질문 갯수로 index 증가하기 구현

<img width="312" alt="스크린샷 2023-10-17 오후 7 03 23" src="https://github.com/DATE-Naeun/Naeun-CLIENT/assets/62435316/103eb3dd-3b33-4844-9975-b7000b4e6ca4">

## Issue
- #8
- Close #8 
